### PR TITLE
Portability fixes for SchemaBuilder on MSSQL

### DIFF
--- a/framework/db/mssql/QueryBuilder.php
+++ b/framework/db/mssql/QueryBuilder.php
@@ -34,10 +34,10 @@ class QueryBuilder extends \yii\db\QueryBuilder
         Schema::TYPE_DOUBLE => 'float',
         Schema::TYPE_DECIMAL => 'decimal',
         Schema::TYPE_DATETIME => 'datetime',
-        Schema::TYPE_TIMESTAMP => 'timestamp',
+        Schema::TYPE_TIMESTAMP => 'datetime',
         Schema::TYPE_TIME => 'time',
         Schema::TYPE_DATE => 'date',
-        Schema::TYPE_BINARY => 'binary(1)',
+        Schema::TYPE_BINARY => 'varbinary(max)',
         Schema::TYPE_BOOLEAN => 'bit',
         Schema::TYPE_MONEY => 'decimal(19,4)',
     ];


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes/no |
| New feature? | yes/no |
| Breaks BC? | yes/no |
| Tests pass? | yes/no |
| Fixed issues | comma-separated list of tickets # fixed by the PR, if any |

Changed binary mapping to `varbinary(max)` on MSSQL instead of `binary(1)` (which requires a length and is fixed length)
to better match other dbms.

Changed timestamp mapping to datetime on MSSQL. Timestamp is a unique number on MSSQL, not a timestamp.

separated from #9191
